### PR TITLE
Make double -> float explicit cast for 32-bit arch

### DIFF
--- a/PureLayout/PureLayout/PureLayout+Internal.h
+++ b/PureLayout/PureLayout/PureLayout+Internal.h
@@ -30,7 +30,7 @@
 
 /** A constant that represents the smallest valid positive value for the multiplier of a constraint,
     since a value of 0 will cause the second item to be lost in the internal auto layout engine. */
-static const CGFloat kMULTIPLIER_MIN_VALUE = 0.00001; // very small floating point numbers (e.g. CGFLOAT_MIN) can cause problems
+static const CGFloat kMULTIPLIER_MIN_VALUE = (CGFloat)0.00001; // very small floating point numbers (e.g. CGFLOAT_MIN) can cause problems
 
 
 /**


### PR DESCRIPTION
With the CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION (aka Wconversion) compiler warning enabled, this line of code causes a compiler warning:

    PureLayout/PureLayout/PureLayout/PureLayout+Internal.h:33:46: warning: implicit conversion loses floating-point precision: 'double' to 'CGFloat' (aka 'float') [-Wconversion]
    static const CGFloat kMULTIPLIER_MIN_VALUE = 0.00001; // very small floating point numbers (e.g. CGFLOAT_MIN) can cause problems
                         ~~~~~~~~~~~~~~~~~~~~~   ^~~~~~~


You have several more implicit casts inside NSArray+PureLayout.m that you might think about fixing too.