### PR TITLE
Align distributed views to superview axis

### DIFF
--- a/PureLayout/PureLayout/NSArray+PureLayout.m
+++ b/PureLayout/PureLayout/NSArray+PureLayout.m
@@ -328,6 +328,9 @@
             else {
                 // First view
                 [constraints addObject:[view autoPinEdgeToSuperviewEdge:firstEdge withInset:leadingSpacing]];
+
+                ALView *commonSuperview = [self al_commonSuperviewOfViews];
+                [constraints addObject:[view al_alignAttribute:alignment toView:commonSuperview forAxis:axis]];
             }
             previousView = view;
         }


### PR DESCRIPTION
This updates the `withFixedSpacing` version of  `autoDistributeViewsAlongAxis` to also align the elements to the common superview axis. I think this makes more intuitive sense and brings it inline with the behavior of the `withFixedSize` version.