### PR TITLE
Made conversion dependent on current architecture

### DIFF
--- a/PureLayout/PureLayout/PureLayout+Internal.h
+++ b/PureLayout/PureLayout/PureLayout+Internal.h
@@ -29,7 +29,7 @@
 
 /** A constant that represents the smallest valid positive value for the multiplier of a constraint,
     since a value of 0 will cause the second item to be lost in the internal auto layout engine. */
-static const CGFloat kMULTIPLIER_MIN_VALUE = 0.00001; // very small floating point numbers (e.g. CGFLOAT_MIN) can cause problems
+static const CGFLOAT_TYPE kMULTIPLIER_MIN_VALUE = (CGFLOAT_TYPE)0.00001; // very small floating point numbers (e.g. CGFLOAT_MIN) can cause problems
 
 
 /**


### PR DESCRIPTION
Fixed `Implicit conversion loses floating point precision: 'double' to 'CGFloat' (aka. 'float')` warning.