### PR TITLE
check if init is need in initForAutoLayout

### DIFF
--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -54,12 +54,19 @@
  */
 - (instancetype)initForAutoLayout
 {
-    if (!self.layer) {
-        self = [self init];
-    }
+    self = [self init];
     if (self) {
         self.translatesAutoresizingMaskIntoConstraints = NO;
     }
+    return self;
+}
+
+/**
+Convert a initialized view into constraints.
+*/
+- (instancetype)configureForAutoLayout
+{
+    self.translatesAutoresizingMaskIntoConstraints = NO;
     return self;
 }
 

--- a/PureLayout/PureLayout/ALView+PureLayout.m
+++ b/PureLayout/PureLayout/ALView+PureLayout.m
@@ -54,7 +54,9 @@
  */
 - (instancetype)initForAutoLayout
 {
-    self = [self init];
+    if (!self.layer) {
+        self = [self init];
+    }
     if (self) {
         self.translatesAutoresizingMaskIntoConstraints = NO;
     }


### PR DESCRIPTION
When I use UIButton with PureLayout:
```objc
UIButton *btn=[UIButton buttonWithType:UIButtonTypeInfoDark];
//I have to write:
 btn.translatesAutoresizingMaskIntoConstraints=NO;
```
I think It's much more better if I can use:
```objc
UIButton *btn=[[UIButton buttonWithType:UIButtonTypeInfoDark] initForAutoLayout]
```
So,I changed `initForAutoLayout` in `ALView+PureLayout.m` to check if `self` really needs `init`

